### PR TITLE
Improve RocksDB build and link 3rd-party libs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,8 @@
 name: Build
-on: push
+on:
+  push:
+    paths-ignore:
+      - .github/workflows/build_rocksdb_*.yaml  # no point building Python bindings when new rocksdb lib is not built yet
 
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,12 +31,13 @@ jobs:
       - name: Install dependencies
         run: pip install pybind11 pytest
 
-      - name: Use clang on macOS
+      - name: Set env vars on macOS
         if: runner.os == 'macOS'
         run: |
-          echo "CC=/usr/bin/clang" >> $GITHUB_ENV
-          echo "CXX=/usr/bin/clang++" >> $GITHUB_ENV
-          echo MACOSX_DEPLOYMENT_TARGET=10.9 >> $GITHUB_ENV
+          echo CC=clang >> $GITHUB_ENV
+          echo CXX=clang++ >> $GITHUB_ENV
+          echo MACOSX_DEPLOYMENT_TARGET=10.13 >> $GITHUB_ENV
+          echo "ARCHFLAGS=-arch x86_64 -arch arm64" >> $GITHUB_ENV
 
       - name: Build
         run: python setup.py build_ext -i

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,6 +36,7 @@ jobs:
         run: |
           echo "CC=/usr/bin/clang" >> $GITHUB_ENV
           echo "CXX=/usr/bin/clang++" >> $GITHUB_ENV
+          echo MACOSX_DEPLOYMENT_TARGET=10.9 >> $GITHUB_ENV
 
       - name: Build
         run: python setup.py build_ext -i

--- a/.github/workflows/build_rocksdb_linux.yaml
+++ b/.github/workflows/build_rocksdb_linux.yaml
@@ -11,15 +11,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          repository: facebook/rocksdb
+          submodules: true
 
       - name: Build 3rd-party libs
         run: |
+          cd rocksdb
           make rocksdbjavastatic_deps -j2
           ls -lh *.a
 
       - name: Build rocksdb
         run: |
+          cd rocksdb
           make static_lib -j2
           strip --strip-debug librocksdb.a
           cat make_config.mk
@@ -32,4 +34,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: rocksdb_${{ runner.os }}
-          path: "*.a"
+          path: "rocksdb/*.a"

--- a/.github/workflows/build_rocksdb_linux.yaml
+++ b/.github/workflows/build_rocksdb_linux.yaml
@@ -29,7 +29,7 @@ jobs:
           PORTABLE: 1
           CFLAGS: -fPIC
           CXXFLAGS: -fPIC
-          EXTRA_CXXFLAGS: -I./bzip2-1.0.8 -I./lz4-1.9.3/lib -I./snappy-1.1.8 -I./snappy-1.1.8/build -I./zlib-1.2.12 -I./zstd-1.4.9/lib
+          EXTRA_CXXFLAGS: -I./bzip2-1.0.8 -I./lz4-1.9.3/lib -I./snappy-1.1.8 -I./snappy-1.1.8/build -I./zlib-1.2.12 -I./zstd-1.4.9/lib -I./zstd-1.4.9/lib/dictBuilder
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_rocksdb_linux.yaml
+++ b/.github/workflows/build_rocksdb_linux.yaml
@@ -29,6 +29,7 @@ jobs:
           PORTABLE: 1
           CFLAGS: -fPIC
           CXXFLAGS: -fPIC
+          EXTRA_CXXFLAGS: -I./bzip2-1.0.8 -I./lz4-1.9.3/lib -I./snappy-1.1.8 -I./snappy-1.1.8/build -I./zlib-1.2.12 -I./zstd-1.4.9/lib
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_rocksdb_mac.yaml
+++ b/.github/workflows/build_rocksdb_mac.yaml
@@ -40,7 +40,7 @@ jobs:
           cat make_config.mk
         env:
           PORTABLE: 1
-          EXTRA_CXXFLAGS: -I./bzip2-1.0.8 -I./lz4-1.9.3/lib -I./snappy-1.1.8 -I./snappy-1.1.8/build -I./zlib-1.2.12 -I./zstd-1.4.9/lib
+          EXTRA_CXXFLAGS: -I./bzip2-1.0.8 -I./lz4-1.9.3/lib -I./snappy-1.1.8 -I./snappy-1.1.8/build -I./zlib-1.2.12 -I./zstd-1.4.9/lib -I./zstd-1.4.9/lib/dictBuilder
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_rocksdb_mac.yaml
+++ b/.github/workflows/build_rocksdb_mac.yaml
@@ -40,6 +40,7 @@ jobs:
           cat make_config.mk
         env:
           PORTABLE: 1
+          EXTRA_CXXFLAGS: -I./bzip2-1.0.8 -I./lz4-1.9.3/lib -I./snappy-1.1.8 -I./snappy-1.1.8/build -I./zlib-1.2.12 -I./zstd-1.4.9/lib
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_rocksdb_mac.yaml
+++ b/.github/workflows/build_rocksdb_mac.yaml
@@ -10,7 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [x86_64, arm64]
+        # arch: [x86_64, arm64]
+        arch: [x86_64]
         
     steps:
       - name: Checkout
@@ -43,36 +44,37 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: rocksdb_${{ runner.os }}_${{ matrix.arch }}
-          path: "*.a"
-
-  create_universal:
-    needs: build
-    runs-on: macos-latest
-    steps:
-      - name: Download x86_64 build
-        uses: actions/download-artifact@v3
-        with:
-          name: rocksdb_${{ runner.os }}_x86_64
-          path: x86_64
-
-      - name: Download arm64 build
-        uses: actions/download-artifact@v3
-        with:
-          name: rocksdb_${{ runner.os }}_arm64
-          path: arm64
-
-      - name: Create universal build
-        run: |
-          for lib in $(ls x86_64/*.a)
-          do
-            filename=${lib##*/}
-            echo "Creating universal lib for $filename"
-            lipo -create -output $filename x86_64/$filename arm64/$filename
-          done
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
           name: rocksdb_${{ runner.os }}
+          # name: rocksdb_${{ runner.os }}_${{ matrix.arch }}
           path: "*.a"
+
+  # create_universal:
+  #   needs: build
+  #   runs-on: macos-latest
+  #   steps:
+  #     - name: Download x86_64 build
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: rocksdb_${{ runner.os }}_x86_64
+  #         path: x86_64
+
+  #     - name: Download arm64 build
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: rocksdb_${{ runner.os }}_arm64
+  #         path: arm64
+
+  #     - name: Create universal build
+  #       run: |
+  #         for lib in $(ls x86_64/*.a)
+  #         do
+  #           filename=${lib##*/}
+  #           echo "Creating universal lib for $filename"
+  #           lipo -create -output $filename x86_64/$filename arm64/$filename
+  #         done
+
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: rocksdb_${{ runner.os }}
+  #         path: "*.a"

--- a/.github/workflows/build_rocksdb_mac.yaml
+++ b/.github/workflows/build_rocksdb_mac.yaml
@@ -12,18 +12,17 @@ jobs:
       matrix:
         arch: [x86_64, arm64]
 
+    env:
+      CC: clang
+      CXX: clang++
+      ARCHFLAG: -arch ${{ matrix.arch }}
+      MACOSX_DEPLOYMENT_TARGET: 10.13
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           submodules: true
-
-      - name: Set env variables
-        run: |
-          echo CC=clang >> $GITHUB_ENV
-          echo CXX=clang++ >> $GITHUB_ENV
-          echo ARCHFLAG="-arch ${{ matrix.arch }}" >> $GITHUB_ENV
-          echo MACOSX_DEPLOYMENT_TARGET=10.9 >> $GITHUB_ENV
 
       - name: Build 3rd-party libs
         run: |

--- a/.github/workflows/build_rocksdb_mac.yaml
+++ b/.github/workflows/build_rocksdb_mac.yaml
@@ -10,14 +10,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # arch: [x86_64, arm64]
-        arch: [x86_64]
-        
+        arch: [x86_64, arm64]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          repository: facebook/rocksdb
+          submodules: true
 
       - name: Set env variables
         run: |
@@ -28,6 +27,7 @@ jobs:
 
       - name: Build 3rd-party libs
         run: |
+          cd rocksdb
           make rocksdbjavastatic_deps -j3
           ls -lh *.a
         env:
@@ -35,6 +35,7 @@ jobs:
 
       - name: Build rocksdb
         run: |
+          cd rocksdb
           make static_lib -j3
           strip librocksdb.a
           cat make_config.mk
@@ -44,37 +45,36 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
+          name: rocksdb_${{ runner.os }}_${{ matrix.arch }}
+          path: "rocksdb/*.a"
+
+  create_universal:
+    needs: build
+    runs-on: macos-latest
+    steps:
+      - name: Download x86_64 build
+        uses: actions/download-artifact@v3
+        with:
+          name: rocksdb_${{ runner.os }}_x86_64
+          path: x86_64
+
+      - name: Download arm64 build
+        uses: actions/download-artifact@v3
+        with:
+          name: rocksdb_${{ runner.os }}_arm64
+          path: arm64
+
+      - name: Create universal build
+        run: |
+          for lib in $(ls x86_64/*.a)
+          do
+            filename=${lib##*/}
+            echo "Creating universal lib for $filename"
+            lipo -create -output $filename x86_64/$filename arm64/$filename
+          done
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
           name: rocksdb_${{ runner.os }}
-          # name: rocksdb_${{ runner.os }}_${{ matrix.arch }}
           path: "*.a"
-
-  # create_universal:
-  #   needs: build
-  #   runs-on: macos-latest
-  #   steps:
-  #     - name: Download x86_64 build
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: rocksdb_${{ runner.os }}_x86_64
-  #         path: x86_64
-
-  #     - name: Download arm64 build
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: rocksdb_${{ runner.os }}_arm64
-  #         path: arm64
-
-  #     - name: Create universal build
-  #       run: |
-  #         for lib in $(ls x86_64/*.a)
-  #         do
-  #           filename=${lib##*/}
-  #           echo "Creating universal lib for $filename"
-  #           lipo -create -output $filename x86_64/$filename arm64/$filename
-  #         done
-
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: rocksdb_${{ runner.os }}
-  #         path: "*.a"

--- a/.github/workflows/build_rocksdb_mac.yaml
+++ b/.github/workflows/build_rocksdb_mac.yaml
@@ -29,7 +29,7 @@ jobs:
           make rocksdbjavastatic_deps -j3
           ls -lh *.a
         env:
-          cc: CC  # zlib bug: https://github.com/madler/zlib/issues/615
+          cc: $CC  # zlib bug: https://github.com/madler/zlib/issues/615
 
       - name: Build rocksdb
         run: |

--- a/.github/workflows/build_rocksdb_mac.yaml
+++ b/.github/workflows/build_rocksdb_mac.yaml
@@ -11,18 +11,17 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x86_64, arm64]
-        
+
+    env:
+      CC: clang
+      CCX: clang++
+      ARCHFLAG: -arch ${{ matrix.arch }}
+    
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           repository: facebook/rocksdb
-
-      - name: Set env variables
-        run: |
-          echo CC=/usr/bin/clang >> $GITHUB_ENV
-          echo CXX=/usr/bin/clang++ >> $GITHUB_ENV
-          echo ARCHFLAG="-arch ${{ matrix.arch }}" >> $GITHUB_ENV
 
       - name: Build 3rd-party libs
         run: |

--- a/.github/workflows/build_rocksdb_mac.yaml
+++ b/.github/workflows/build_rocksdb_mac.yaml
@@ -23,6 +23,7 @@ jobs:
           echo CC=clang >> $GITHUB_ENV
           echo CXX=clang++ >> $GITHUB_ENV
           echo ARCHFLAG="-arch ${{ matrix.arch }}" >> $GITHUB_ENV
+          echo MACOSX_DEPLOYMENT_TARGET=10.9 >> $GITHUB_ENV
 
       - name: Build 3rd-party libs
         run: |

--- a/.github/workflows/build_rocksdb_mac.yaml
+++ b/.github/workflows/build_rocksdb_mac.yaml
@@ -11,17 +11,18 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x86_64, arm64]
-
-    env:
-      CC: /usr/bin/clang
-      CCX: /usr/bin/clang++
-      ARCHFLAG: -arch ${{ matrix.arch }}
-    
+        
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           repository: facebook/rocksdb
+
+      - name: Set env variables
+        run: |
+          echo CC=clang >> $GITHUB_ENV
+          echo CXX=clang++ >> $GITHUB_ENV
+          echo ARCHFLAG="-arch ${{ matrix.arch }}" >> $GITHUB_ENV
 
       - name: Build 3rd-party libs
         run: |

--- a/.github/workflows/build_rocksdb_mac.yaml
+++ b/.github/workflows/build_rocksdb_mac.yaml
@@ -13,8 +13,8 @@ jobs:
         arch: [x86_64, arm64]
 
     env:
-      CC: clang
-      CCX: clang++
+      CC: /usr/bin/clang
+      CCX: /usr/bin/clang++
       ARCHFLAG: -arch ${{ matrix.arch }}
     
     steps:
@@ -25,7 +25,6 @@ jobs:
 
       - name: Build 3rd-party libs
         run: |
-          echo $ARCHFLAG
           make rocksdbjavastatic_deps -j3
           ls -lh *.a
         env:

--- a/.github/workflows/build_rocksdb_mac.yaml
+++ b/.github/workflows/build_rocksdb_mac.yaml
@@ -29,7 +29,7 @@ jobs:
           make rocksdbjavastatic_deps -j3
           ls -lh *.a
         env:
-          cc: $CC  # zlib bug: https://github.com/madler/zlib/issues/615
+          cc: clang  # zlib bug: https://github.com/madler/zlib/issues/615
 
       - name: Build rocksdb
         run: |

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -9,9 +9,14 @@ env:
   MSBUILD_FLAGS: /m:2 /p:Configuration=Release /p:Platform=x64
 
 jobs:
-  build_3rd_party:
+  build:
     runs-on: windows-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
 
@@ -50,30 +55,30 @@ jobs:
           msbuild zstd.sln ${{ env.MSBUILD_FLAGS }}
           cp lib/Release/*.lib ../..
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: rocksdb_${{ runner.os }}
-          path: "*.lib"
-
-  build_rocksdb:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.1
-
       - name: Build rocksdb
         run: |
           mkdir rocksdb/build
           cd rocksdb/build
-          cmake ${{ env.CMAKE_FLAGS }} -DPORTABLE=1 -DROCKSDB_BUILD_SHARED=0 -DWITH_BENCHMARK_TOOLS=0 -DWITH_CORE_TOOLS=0 -DWITH_TOOLS=0 ..
+          cmake ${{ env.CMAKE_FLAGS }} -DWITH_SNAPPY=1 -DWITH_LZ4=1 -DWITH_ZLIB=1 -DWITH_ZSTD=1 -DXPRESS=1 \
+            -DPORTABLE=1 -DROCKSDB_BUILD_SHARED=0 -DWITH_BENCHMARK_TOOLS=0 -DWITH_CORE_TOOLS=0 -DWITH_TOOLS=0 ..
           msbuild rocksdb.sln ${{ env.MSBUILD_FLAGS }}
           cp Release/*.lib ../..
+        env:
+          SNAPPY_HOME: ./snappy
+          SNAPPY_INCLUDE: ./snappy;./snappy/build
+          SNAPPY_LIB_RELEASE: ./snappy.lib
+
+          LZ4_HOME: ./lz4
+          LZ4_INCLUDE: ./lz4/lib
+          LZ4_LIB_RELEASE: ./lz4.lib
+
+          ZLIB_HOME: ./zlib
+          ZLIB_INCLUDE: ./zlib
+          ZLIB_LIB_RELEASE: ./zlib.lib
+
+          ZSTD_HOME: ./zstd
+          ZSTD_INCLUDE: ./zstd/lib;./zstd/lib/dictBuilder
+          ZSTD_LIB_RELEASE: ./zstd.lib
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           git clone https://github.com/lz4/lz4
           cd lz4
-          git checkout ${{ env.LZ4_VER }}
+          git checkout v${{ env.LZ4_VER }}
           cd build
           cmake ${{ env.CMAKE_FLAGS }} -DLZ4_BUILD_CLI=0 -DLZ4_BUILD_LEGACY_LZ4C=0 -DLZ4_BUNDLED_MODE=1 ./cmake
           msbuild LZ4.sln ${{ env.MSBUILD_FLAGS }}
@@ -51,7 +51,7 @@ jobs:
         run: |
           git clone https://github.com/madler/zlib
           cd zlib
-          git checkout ${{ env.ZLIB_VER }}
+          git checkout v${{ env.ZLIB_VER }}
           mkdir build
           cd build
           cmake ${{ env.CMAKE_FLAGS }} -DAMD64=0 ..
@@ -62,7 +62,7 @@ jobs:
         run: |
           git clone https://github.com/facebook/zstd
           cd zstd
-          git checkout ${{ env.ZSTD_VER }}
+          git checkout v${{ env.ZSTD_VER }}
           cd build
           cmake ${{ env.CMAKE_FLAGS }} -DZSTD_LEGACY_SUPPORT=0 -DZSTD_BUILD_PROGRAMS=0 -DZSTD_BUILD_TESTS=0 ./cmake
           msbuild zstd.sln ${{ env.MSBUILD_FLAGS }}

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build_3rd_party:
-    runs-on: windows-latest        
+    runs-on: windows-latest
     steps:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
@@ -49,7 +49,7 @@ jobs:
           cmake ${{ env.CMAKE_FLAGS }} -DZSTD_LEGACY_SUPPORT=0 -DZSTD_BUILD_PROGRAMS=0 -DZSTD_BUILD_TESTS=0 ./cmake
           msbuild zstd.sln ${{ env.MSBUILD_FLAGS }}
           cp lib/Release/*.lib ../..
-          
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -57,24 +57,23 @@ jobs:
           path: "*.lib"
 
   build_rocksdb:
-    runs-on: windows-latest        
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          repository: facebook/rocksdb
+          submodules: true
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
 
       - name: Build rocksdb
         run: |
-          mkdir build
-          cd build
+          mkdir rocksdb/build
+          cd rocksdb/build
           cmake ${{ env.CMAKE_FLAGS }} -DPORTABLE=1 -DROCKSDB_BUILD_SHARED=0 -DWITH_BENCHMARK_TOOLS=0 -DWITH_CORE_TOOLS=0 -DWITH_TOOLS=0 ..
           msbuild rocksdb.sln ${{ env.MSBUILD_FLAGS }}
-          cp Release/*.lib ..
-          ls *.lib
+          cp Release/*.lib ../..
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -9,7 +9,7 @@ env:
   MSBUILD_FLAGS: /m:2 /p:Configuration=Release /p:Platform=x64
 
 jobs:
-  build:
+  build_3rd_party:
     runs-on: windows-latest        
     steps:
       - name: Add msbuild to PATH
@@ -18,9 +18,8 @@ jobs:
       - name: Build Snappy
         run: |
           git clone https://github.com/google/snappy/
-          cd snappy
-          mkdir build
-          cd build
+          mkdir snappy/build
+          cd snappy/build
           cmake ${{ env.CMAKE_FLAGS }} -DSNAPPY_BUILD_TESTS=OFF -DSNAPPY_BUILD_BENCHMARKS=OFF ..
           msbuild Snappy.sln ${{ env.MSBUILD_FLAGS }}
           cp Release/*.lib ../..
@@ -29,14 +28,26 @@ jobs:
         run: |
           git clone https://github.com/lz4/lz4
           cd lz4/build
-          cmake -G "Visual Studio 17 2022" -A x64 -DLZ4_BUILD_CLI=0 -DLZ4_BUILD_LEGACY_LZ4C=0 -DLZ4_BUNDLED_MODE=1 ./cmake
-          msbuild LZ4.sln /p:Configuration=Release /p:Platform=x64
+          cmake ${{ env.CMAKE_FLAGS }} -DLZ4_BUILD_CLI=0 -DLZ4_BUILD_LEGACY_LZ4C=0 -DLZ4_BUNDLED_MODE=1 ./cmake
+          msbuild LZ4.sln ${{ env.MSBUILD_FLAGS }}
           cp Release/*.lib ../..
 
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: rocksdb_${{ runner.os }}
+          path: "*.lib"
+
+  build_rocksdb:
+    runs-on: windows-latest        
+    steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           repository: facebook/rocksdb
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
 
       - name: Build rocksdb
         run: |

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -64,21 +64,23 @@ jobs:
           msbuild rocksdb.sln ${{ env.MSBUILD_FLAGS }}
           cp Release/*.lib ../..
         env:
-          SNAPPY_HOME: ../snappy
-          SNAPPY_INCLUDE: ../snappy;../snappy/build
-          SNAPPY_LIB_RELEASE: ../snappy.lib
+          THIRD_PARTY_HOME: ${{ github.workspace }}
 
-          LZ4_HOME: ../lz4
-          LZ4_INCLUDE: ../lz4/lib
-          LZ4_LIB_RELEASE: ../lz4.lib
+          SNAPPY_HOME: ${{ github.workspace }}/snappy
+          SNAPPY_INCLUDE: ${{ github.workspace }}/snappy;${{ github.workspace }}/snappy/build
+          SNAPPY_LIB_RELEASE: ${{ github.workspace }}/snappy.lib
 
-          ZLIB_HOME: ../zlib
-          ZLIB_INCLUDE: ../zlib
-          ZLIB_LIB_RELEASE: ../zlib.lib
+          LZ4_HOME: ${{ github.workspace }}/lz4
+          LZ4_INCLUDE: ${{ github.workspace }}/lz4/lib
+          LZ4_LIB_RELEASE: ${{ github.workspace }}/lz4.lib
 
-          ZSTD_HOME: ../zstd
-          ZSTD_INCLUDE: ../zstd/lib;../zstd/lib/dictBuilder
-          ZSTD_LIB_RELEASE: ../zstd.lib
+          ZLIB_HOME: ${{ github.workspace }}/zlib
+          ZLIB_INCLUDE: ${{ github.workspace }}/zlib
+          ZLIB_LIB_RELEASE: ${{ github.workspace }}/zlib.lib
+
+          ZSTD_HOME: ${{ github.workspace }}/zstd
+          ZSTD_INCLUDE: ${{ github.workspace }}/zstd/lib;${{ github.workspace }}/zstd/lib/dictBuilder
+          ZSTD_LIB_RELEASE: ${{ github.workspace }}/zstd.lib
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -59,7 +59,7 @@ jobs:
         run: |
           mkdir rocksdb/build
           cd rocksdb/build
-          cmake ${{ env.CMAKE_FLAGS }} -DWITH_SNAPPY=1 -DWITH_LZ4=1 -DWITH_ZLIB=1 -DWITH_ZSTD=1 -DXPRESS=1 \
+          cmake ${{ env.CMAKE_FLAGS }} -DWITH_SNAPPY=1 -DWITH_LZ4=1 -DWITH_ZLIB=1 -DWITH_ZSTD=1 -DXPRESS=1 `
             -DPORTABLE=1 -DROCKSDB_BUILD_SHARED=0 -DWITH_BENCHMARK_TOOLS=0 -DWITH_CORE_TOOLS=0 -DWITH_TOOLS=0 ..
           msbuild rocksdb.sln ${{ env.MSBUILD_FLAGS }}
           cp Release/*.lib ../..

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -32,7 +32,7 @@ jobs:
           git checkout ${{ env.SNAPPY_VER }}
           mkdir build
           cd build
-          cmake ${{ env.CMAKE_FLAGS }} -DSNAPPY_BUILD_TESTS=OFF -DSNAPPY_BUILD_BENCHMARKS=OFF ..
+          cmake ${{ env.CMAKE_FLAGS }} -DSNAPPY_BUILD_TESTS=0 ..
           msbuild Snappy.sln ${{ env.MSBUILD_FLAGS }}
           cp Release/*.lib ../..
 
@@ -89,11 +89,11 @@ jobs:
 
           ZLIB_HOME: ${{ github.workspace }}/zlib
           ZLIB_INCLUDE: ${{ github.workspace }}/zlib;${{ github.workspace }}/zlib/build
-          ZLIB_LIB_RELEASE: ${{ github.workspace }}/zlib.lib
+          ZLIB_LIB_RELEASE: ${{ github.workspace }}/zlibstatic.lib
 
           ZSTD_HOME: ${{ github.workspace }}/zstd
           ZSTD_INCLUDE: ${{ github.workspace }}/zstd/lib;${{ github.workspace }}/zstd/lib/dictBuilder
-          ZSTD_LIB_RELEASE: ${{ github.workspace }}/zstd.lib
+          ZSTD_LIB_RELEASE: ${{ github.workspace }}/zstd_static.lib
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -12,13 +12,31 @@ jobs:
   build:
     runs-on: windows-latest        
     steps:
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+
+      - name: Build Snappy
+        run: |
+          git clone https://github.com/google/snappy/
+          cd snappy
+          mkdir build
+          cd build
+          cmake ${{ env.CMAKE_FLAGS }} -DSNAPPY_BUILD_TESTS=OFF -DSNAPPY_BUILD_BENCHMARKS=OFF ..
+          msbuild Snappy.sln ${{ env.MSBUILD_FLAGS }}
+          cp Release/*.lib ../..
+
+      - name: Build LZ4
+        run: |
+          git clone https://github.com/lz4/lz4
+          cd lz4/build
+          cmake -G "Visual Studio 17 2022" -A x64 -DLZ4_BUILD_CLI=0 -DLZ4_BUILD_LEGACY_LZ4C=0 -DLZ4_BUNDLED_MODE=1 ./cmake
+          msbuild LZ4.sln /p:Configuration=Release /p:Platform=x64
+          cp Release/*.lib ../..
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
           repository: facebook/rocksdb
-
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.1
 
       - name: Build rocksdb
         run: |
@@ -26,10 +44,11 @@ jobs:
           cd build
           cmake ${{ env.CMAKE_FLAGS }} -DPORTABLE=1 -DROCKSDB_BUILD_SHARED=0 -DWITH_BENCHMARK_TOOLS=0 -DWITH_CORE_TOOLS=0 -DWITH_TOOLS=0 ..
           msbuild rocksdb.sln ${{ env.MSBUILD_FLAGS }}
-          ls Release
+          cp Release/*.lib ..
+          ls *.lib
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: rocksdb_${{ runner.os }}
-          path: build/Release/rocksdb.lib
+          path: "*.lib"

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -77,23 +77,21 @@ jobs:
           msbuild rocksdb.sln ${{ env.MSBUILD_FLAGS }}
           cp Release/*.lib ../..
         env:
-          # THIRD_PARTY_HOME: ${{ github.workspace }}
+          SNAPPY_HOME: ../snappy
+          SNAPPY_INCLUDE: ../snappy;../snappy/build
+          SNAPPY_LIB_RELEASE: ../snappy.lib
 
-          SNAPPY_HOME: ../../snappy
-          SNAPPY_INCLUDE: ../../snappy;../../snappy/build
-          SNAPPY_LIB_RELEASE: ../../snappy.lib
+          LZ4_HOME: ../lz4
+          LZ4_INCLUDE: ../lz4/lib
+          LZ4_LIB_RELEASE: ../lz4.lib
 
-          LZ4_HOME: ../../lz4
-          LZ4_INCLUDE: ../../lz4/lib
-          LZ4_LIB_RELEASE: ../../lz4.lib
+          ZLIB_HOME: ../zlib
+          ZLIB_INCLUDE: ../zlib;../zlib/build
+          ZLIB_LIB_RELEASE: ../zlibstatic.lib
 
-          ZLIB_HOME: ../../zlib
-          ZLIB_INCLUDE: ../../zlib;../../zlib/build
-          ZLIB_LIB_RELEASE: ../../zlibstatic.lib
-
-          ZSTD_HOME: ../../zstd
-          ZSTD_INCLUDE: ../../zstd/lib;../../zstd/lib/dictBuilder
-          ZSTD_LIB_RELEASE: ../../zstd_static.lib
+          ZSTD_HOME: ../zstd
+          ZSTD_INCLUDE: ../zstd/lib;../zstd/lib/dictBuilder
+          ZSTD_LIB_RELEASE: ../zstd_static.lib
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -48,7 +48,7 @@ jobs:
           cd zstd/build
           cmake ${{ env.CMAKE_FLAGS }} -DZSTD_LEGACY_SUPPORT=0 -DZSTD_BUILD_PROGRAMS=0 -DZSTD_BUILD_TESTS=0 ./cmake
           msbuild zstd.sln ${{ env.MSBUILD_FLAGS }}
-          cp Release/*.lib ../..
+          cp Release/lib/*.lib ../..
           
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -79,21 +79,21 @@ jobs:
         env:
           THIRD_PARTY_HOME: ${{ github.workspace }}
 
-          SNAPPY_HOME: ${{ github.workspace }}/snappy
-          SNAPPY_INCLUDE: ${{ github.workspace }}/snappy;${{ github.workspace }}/snappy/build
-          SNAPPY_LIB_RELEASE: ${{ github.workspace }}/snappy.lib
+          SNAPPY_HOME: snappy
+          SNAPPY_INCLUDE: snappy;snappy/build
+          SNAPPY_LIB_RELEASE: snappy.lib
 
-          LZ4_HOME: ${{ github.workspace }}/lz4
-          LZ4_INCLUDE: ${{ github.workspace }}/lz4/lib
-          LZ4_LIB_RELEASE: ${{ github.workspace }}/lz4.lib
+          LZ4_HOME: lz4
+          LZ4_INCLUDE: lz4/lib
+          LZ4_LIB_RELEASE: lz4.lib
 
-          ZLIB_HOME: ${{ github.workspace }}/zlib
-          ZLIB_INCLUDE: ${{ github.workspace }}/zlib;${{ github.workspace }}/zlib/build
-          ZLIB_LIB_RELEASE: ${{ github.workspace }}/zlibstatic.lib
+          ZLIB_HOME: zlib
+          ZLIB_INCLUDE: zlib;zlib/build
+          ZLIB_LIB_RELEASE: zlibstatic.lib
 
-          ZSTD_HOME: ${{ github.workspace }}/zstd
-          ZSTD_INCLUDE: ${{ github.workspace }}/zstd/lib;${{ github.workspace }}/zstd/lib/dictBuilder
-          ZSTD_LIB_RELEASE: ${{ github.workspace }}/zstd_static.lib
+          ZSTD_HOME: zstd
+          ZSTD_INCLUDE: zstd/lib;zstd/lib/dictBuilder
+          ZSTD_LIB_RELEASE: zstd_static.lib
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -32,6 +32,24 @@ jobs:
           msbuild LZ4.sln ${{ env.MSBUILD_FLAGS }}
           cp Release/*.lib ../..
 
+      # there are problems with assembly code: https://github.com/madler/zlib/issues/631
+      - name: Build ZLib
+        run: |
+          git clone https://github.com/madler/zlib
+          mkdir zlib/build
+          cd zlib/build
+          cmake ${{ env.CMAKE_FLAGS }} -DAMD64=0 ..
+          msbuild LZ4.sln ${{ env.MSBUILD_FLAGS }}
+          cp Release/*.lib ../..
+
+      - name: Build Zstd
+        run: |
+          git clone https://github.com/facebook/zstd
+          cd zstd/build
+          cmake ${{ env.CMAKE_FLAGS }} -DZSTD_LEGACY_SUPPORT=0 -DZSTD_BUILD_PROGRAMS=0 -DZSTD_BUILD_TESTS=0 ./cmake
+          msbuild zstd.sln ${{ env.MSBUILD_FLAGS }}
+          cp Release/*.lib ../..
+          
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -39,7 +39,7 @@ jobs:
           mkdir zlib/build
           cd zlib/build
           cmake ${{ env.CMAKE_FLAGS }} -DAMD64=0 ..
-          msbuild LZ4.sln ${{ env.MSBUILD_FLAGS }}
+          msbuild zlib.sln ${{ env.MSBUILD_FLAGS }}
           cp Release/*.lib ../..
 
       - name: Build Zstd

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -22,6 +22,7 @@ jobs:
 
       - name: Build Snappy
         run: |
+          echo ${{ github.workspace }}
           git clone https://github.com/google/snappy/
           mkdir snappy/build
           cd snappy/build

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -8,6 +8,11 @@ env:
   CMAKE_FLAGS: -G "Visual Studio 17 2022" -A x64 -DCMAKE_GENERATOR_PLATFORM=x64 -DCMAKE_BUILD_TYPE=Release
   MSBUILD_FLAGS: /m:2 /p:Configuration=Release /p:Platform=x64
 
+  SNAPPY_VER: "1.1.8"
+  LZ4_VER: "1.9.3"
+  ZLIB_VER: "1.2.12"
+  ZSTD_VER: "1.4.9"
+
 jobs:
   build:
     runs-on: windows-latest
@@ -23,8 +28,10 @@ jobs:
       - name: Build Snappy
         run: |
           git clone https://github.com/google/snappy/
-          mkdir snappy/build
-          cd snappy/build
+          cd snappy
+          git checkout ${{ env.SNAPPY_VER }}
+          mkdir build
+          cd build
           cmake ${{ env.CMAKE_FLAGS }} -DSNAPPY_BUILD_TESTS=OFF -DSNAPPY_BUILD_BENCHMARKS=OFF ..
           msbuild Snappy.sln ${{ env.MSBUILD_FLAGS }}
           cp Release/*.lib ../..
@@ -32,7 +39,9 @@ jobs:
       - name: Build LZ4
         run: |
           git clone https://github.com/lz4/lz4
-          cd lz4/build
+          cd lz4
+          git checkout ${{ env.LZ4_VER }}
+          cd build
           cmake ${{ env.CMAKE_FLAGS }} -DLZ4_BUILD_CLI=0 -DLZ4_BUILD_LEGACY_LZ4C=0 -DLZ4_BUNDLED_MODE=1 ./cmake
           msbuild LZ4.sln ${{ env.MSBUILD_FLAGS }}
           cp Release/*.lib ../..
@@ -41,8 +50,10 @@ jobs:
       - name: Build ZLib
         run: |
           git clone https://github.com/madler/zlib
-          mkdir zlib/build
-          cd zlib/build
+          cd zlib
+          git checkout ${{ env.ZLIB_VER }}
+          mkdir build
+          cd build
           cmake ${{ env.CMAKE_FLAGS }} -DAMD64=0 ..
           msbuild zlib.sln ${{ env.MSBUILD_FLAGS }}
           cp Release/*.lib ../..
@@ -50,7 +61,9 @@ jobs:
       - name: Build Zstd
         run: |
           git clone https://github.com/facebook/zstd
-          cd zstd/build
+          cd zstd
+          git checkout ${{ env.ZSTD_VER }}
+          cd build
           cmake ${{ env.CMAKE_FLAGS }} -DZSTD_LEGACY_SUPPORT=0 -DZSTD_BUILD_PROGRAMS=0 -DZSTD_BUILD_TESTS=0 ./cmake
           msbuild zstd.sln ${{ env.MSBUILD_FLAGS }}
           cp lib/Release/*.lib ../..

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -22,7 +22,6 @@ jobs:
 
       - name: Build Snappy
         run: |
-          echo ${{ github.workspace }}
           git clone https://github.com/google/snappy/
           mkdir snappy/build
           cd snappy/build
@@ -65,21 +64,21 @@ jobs:
           msbuild rocksdb.sln ${{ env.MSBUILD_FLAGS }}
           cp Release/*.lib ../..
         env:
-          SNAPPY_HOME: ./snappy
-          SNAPPY_INCLUDE: ./snappy;./snappy/build
-          SNAPPY_LIB_RELEASE: ./snappy.lib
+          SNAPPY_HOME: ../snappy
+          SNAPPY_INCLUDE: ../snappy;../snappy/build
+          SNAPPY_LIB_RELEASE: ../snappy.lib
 
-          LZ4_HOME: ./lz4
-          LZ4_INCLUDE: ./lz4/lib
-          LZ4_LIB_RELEASE: ./lz4.lib
+          LZ4_HOME: ../lz4
+          LZ4_INCLUDE: ../lz4/lib
+          LZ4_LIB_RELEASE: ../lz4.lib
 
-          ZLIB_HOME: ./zlib
-          ZLIB_INCLUDE: ./zlib
-          ZLIB_LIB_RELEASE: ./zlib.lib
+          ZLIB_HOME: ../zlib
+          ZLIB_INCLUDE: ../zlib
+          ZLIB_LIB_RELEASE: ../zlib.lib
 
-          ZSTD_HOME: ./zstd
-          ZSTD_INCLUDE: ./zstd/lib;./zstd/lib/dictBuilder
-          ZSTD_LIB_RELEASE: ./zstd.lib
+          ZSTD_HOME: ../zstd
+          ZSTD_INCLUDE: ../zstd/lib;../zstd/lib/dictBuilder
+          ZSTD_LIB_RELEASE: ../zstd.lib
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -4,6 +4,10 @@ on:
     paths:
      - .github/workflows/build_rocksdb_win.yaml
 
+env:
+  CMAKE_FLAGS: -G "Visual Studio 17 2022" -A x64 -DCMAKE_GENERATOR_PLATFORM=x64 -DCMAKE_BUILD_TYPE=Release
+  MSBUILD_FLAGS: /m:2 /p:Configuration=Release /p:Platform=x64
+
 jobs:
   build:
     runs-on: windows-latest        
@@ -20,8 +24,8 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Release -DPORTABLE=1 -DROCKSDB_BUILD_SHARED=0 -DWITH_BENCHMARK_TOOLS=0 -DWITH_CORE_TOOLS=0 -DWITH_TOOLS=0 ..
-          msbuild rocksdb.sln /m:2 /p:Configuration=Release
+          cmake ${{ env.CMAKE_FLAGS }} -DPORTABLE=1 -DROCKSDB_BUILD_SHARED=0 -DWITH_BENCHMARK_TOOLS=0 -DWITH_CORE_TOOLS=0 -DWITH_TOOLS=0 ..
+          msbuild rocksdb.sln ${{ env.MSBUILD_FLAGS }}
           ls Release
 
       - name: Upload artifacts

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -75,7 +75,7 @@ jobs:
           LZ4_LIB_RELEASE: ${{ github.workspace }}/lz4.lib
 
           ZLIB_HOME: ${{ github.workspace }}/zlib
-          ZLIB_INCLUDE: ${{ github.workspace }}/zlib
+          ZLIB_INCLUDE: ${{ github.workspace }}/zlib;${{ github.workspace }}/zlib/build
           ZLIB_LIB_RELEASE: ${{ github.workspace }}/zlib.lib
 
           ZSTD_HOME: ${{ github.workspace }}/zstd

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -48,7 +48,7 @@ jobs:
           cd zstd/build
           cmake ${{ env.CMAKE_FLAGS }} -DZSTD_LEGACY_SUPPORT=0 -DZSTD_BUILD_PROGRAMS=0 -DZSTD_BUILD_TESTS=0 ./cmake
           msbuild zstd.sln ${{ env.MSBUILD_FLAGS }}
-          cp Release/lib/*.lib ../..
+          cp lib/Release/*.lib ../..
           
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_rocksdb_win.yaml
+++ b/.github/workflows/build_rocksdb_win.yaml
@@ -77,23 +77,23 @@ jobs:
           msbuild rocksdb.sln ${{ env.MSBUILD_FLAGS }}
           cp Release/*.lib ../..
         env:
-          THIRD_PARTY_HOME: ${{ github.workspace }}
+          # THIRD_PARTY_HOME: ${{ github.workspace }}
 
-          SNAPPY_HOME: snappy
-          SNAPPY_INCLUDE: snappy;snappy/build
-          SNAPPY_LIB_RELEASE: snappy.lib
+          SNAPPY_HOME: ../../snappy
+          SNAPPY_INCLUDE: ../../snappy;../../snappy/build
+          SNAPPY_LIB_RELEASE: ../../snappy.lib
 
-          LZ4_HOME: lz4
-          LZ4_INCLUDE: lz4/lib
-          LZ4_LIB_RELEASE: lz4.lib
+          LZ4_HOME: ../../lz4
+          LZ4_INCLUDE: ../../lz4/lib
+          LZ4_LIB_RELEASE: ../../lz4.lib
 
-          ZLIB_HOME: zlib
-          ZLIB_INCLUDE: zlib;zlib/build
-          ZLIB_LIB_RELEASE: zlibstatic.lib
+          ZLIB_HOME: ../../zlib
+          ZLIB_INCLUDE: ../../zlib;../../zlib/build
+          ZLIB_LIB_RELEASE: ../../zlibstatic.lib
 
-          ZSTD_HOME: zstd
-          ZSTD_INCLUDE: zstd/lib;zstd/lib/dictBuilder
-          ZSTD_LIB_RELEASE: zstd_static.lib
+          ZSTD_HOME: ../../zstd
+          ZSTD_INCLUDE: ../../zstd/lib;../../zstd/lib/dictBuilder
+          ZSTD_LIB_RELEASE: ../../zstd_static.lib
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "rocksdb"]
 	path = rocksdb
 	url = https://github.com/facebook/rocksdb.git
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "rocksdb"]
 	path = rocksdb
 	url = https://github.com/facebook/rocksdb.git
-	branch = main
+	tag = v7.3.1

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,14 @@ __version__ = "0.0.1"
 
 
 def get_libraries():
-    libraries = ["rocksdb"]
+    libraries = ["rocksdb", "lz4", "snappy", "zstd"]
     if IS_WIN:
         # for port_win.cc
-        libraries.extend(["Rpcrt4", "Shlwapi"])
+        libraries.extend(["Rpcrt4", "Shlwapi", "zlib"])
     else:
-        libraries.extend(["bz2", "lz4", "snappy", "z", "zstd"])
+        # bz2 not available on Windows
+        # zlib is z on Unix
+        libraries.extend(["bz2", "z"])
     return libraries
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ def get_libraries():
     libraries = ["rocksdb", "lz4", "snappy", "zstd"]
     if IS_WIN:
         # for port_win.cc
-        libraries.extend(["Rpcrt4", "Shlwapi", "zlib"])
+        # Cabinet is for XPRESS
+        libraries.extend(["Rpcrt4", "Shlwapi", "zlib", "Cabinet"])
     else:
         # bz2 not available on Windows
         # zlib is z on Unix

--- a/setup.py
+++ b/setup.py
@@ -9,15 +9,13 @@ __version__ = "0.0.1"
 
 
 def get_libraries():
-    libraries = ["rocksdb", "lz4", "snappy", "zstd"]
+    libraries = ["rocksdb", "lz4", "snappy"]
     if IS_WIN:
-        # for port_win.cc
-        # Cabinet is for XPRESS
-        libraries.extend(["Rpcrt4", "Shlwapi", "zlib", "Cabinet"])
+        libraries.extend(["Rpcrt4", "Shlwapi"]) # for port_win.cc
+        libraries.extend(["zlibstatic", "zstd_static"])
+        libraries.append("Cabinet") # for XPRESS
     else:
-        # bz2 not available on Windows
-        # zlib is z on Unix
-        libraries.extend(["bz2", "z"])
+        libraries.extend(["bz2", "z", "zstd"])
     return libraries
 
 


### PR DESCRIPTION
- Pin rocksdb to v7.3.1
- Build all supported 3rd-party compression libraries: snappy, lz4, zlib, bzip2, zstd (no bzip2 on Windows)
- Link all 3rd-party compression libraries in the Python bindings